### PR TITLE
bugfix/FBA-executor-button-identification

### DIFF
--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/FBASeleniumApplicationExecutor.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/FBASeleniumApplicationExecutor.java
@@ -3,7 +3,6 @@ package edu.iastate.ece.sd.sdmay2126.runner.selenium;
 import edu.iastate.ece.sd.sdmay2126.orchestration.Job;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
@@ -17,6 +16,9 @@ public class FBASeleniumApplicationExecutor implements SeleniumApplicationExecut
 
     @Override
     public void executeApplication(Job job) {
-        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("button[data-button='runApp']"))).click();
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(d -> d.findElements(By.cssSelector("button[data-button='runApp']")))
+                .get(2) // FBA is the 3rd application on the page, thus the 3rd run button (0-indexed)
+                .click();
     }
 }


### PR DESCRIPTION
Quick fix for the "Run" button selection not accounting for other cards in the narrative also having "Run" buttons. Related to #29.

Note that #33 is intended to address this with a more robust solution.