### PR TITLE
feature/Runner-failure-handling

### DIFF
--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/orchestration/Job.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/orchestration/Job.java
@@ -13,17 +13,20 @@ public class Job {
     private ApplicationParameters parameters;
     private JobCompleted completionCallback;
     private JobCanceled cancellationCallback;
+    private JobFailed failureCallback;
     private ApplicationOutput output;
     private JobResult result = JobResult.UNKNOWN;
 
     public Job(ApplicationParameters parameters) {
-        this(parameters, null, null);
+        this(parameters, null, null, null);
     }
 
-    public Job(@NotNull ApplicationParameters parameters, JobCompleted completionCallback, JobCanceled cancellationCallback) {
+    public Job(@NotNull ApplicationParameters parameters, JobCompleted completionCallback,
+               JobCanceled cancellationCallback, JobFailed failureCallback) {
         this.parameters = parameters;
         this.completionCallback = completionCallback;
         this.cancellationCallback = cancellationCallback;
+        this.failureCallback = failureCallback;
     }
 
     public ApplicationType getApplication() {
@@ -48,6 +51,10 @@ public class Job {
 
     public JobCanceled getCancellationCallback() {
         return cancellationCallback;
+    }
+
+    public JobFailed getFailureCallback() {
+        return failureCallback;
     }
 
     public void setOutput(ApplicationOutput output) {

--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/orchestration/JobFailed.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/orchestration/JobFailed.java
@@ -1,0 +1,13 @@
+package edu.iastate.ece.sd.sdmay2126.orchestration;
+
+/**
+ * Callback for taking action after some job has failed execution.
+ */
+public interface JobFailed {
+    /**
+     * Called in instances where a job's execution fails.
+     * @param job The job which failed.
+     * @param cause Optionally, a cause for the failure.
+     */
+    void onFailure(Job job, Throwable cause);
+}

--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/orchestration/JobManager.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/orchestration/JobManager.java
@@ -105,6 +105,16 @@ public class JobManager implements Runnable {
         stopped = true;
     }
 
+    /**
+     * Used to notify the manager and possibly caller of a job failure, depending on job configuration.
+     * @param job The job which has failed during execution.
+     * @param cause Optionally, a cause for the failure.
+     */
+    public void notifyOfFailure(Job job, Throwable cause) {
+        if (job.getFailureCallback() != null)
+            job.getFailureCallback().onFailure(job, cause);
+    }
+
     @Override
     public void run() {
         // First we have the execution loop

--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/orchestration/JobManager.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/orchestration/JobManager.java
@@ -113,6 +113,9 @@ public class JobManager implements Runnable {
     public void notifyOfFailure(Job job, Throwable cause) {
         if (job.getFailureCallback() != null)
             job.getFailureCallback().onFailure(job, cause);
+        else
+            // Fallback to the console if the UI isn't handling it
+            cause.printStackTrace();
     }
 
     @Override

--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/SeleniumRunner.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/SeleniumRunner.java
@@ -83,11 +83,15 @@ public class SeleniumRunner implements Runner {
                     nextJob.setResult(JobResult.SUCCESS);
                 }
                 catch (RunnerNotInitializedException | InvalidApplicationException | SeleniumIdentificationException e) {
+                    // TODO: Either scope logging to the runner, or delegate this to the job's callback with a faillback to the manager
                     System.err.println("A job has failed, but the runner will reset and continue execution.");
                     e.printStackTrace();
 
                     // Flag the job as failed
                     nextJob.setResult(JobResult.FAILURE);
+
+                    // Notify the manager of the failure
+                    jobManager.notifyOfFailure(nextJob, e);
                 }
 
                 // Reopen availability and notify the manager

--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/SeleniumRunner.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/SeleniumRunner.java
@@ -79,20 +79,26 @@ public class SeleniumRunner implements Runner {
                     // Execute the job, provided that the session is ready
                     executeRunner(nextJob);
 
-                    // Update the job's result status
-                    // TODO: Set to FAILURE for the recoverable and job-specific failures
+                    // If we made it here, things should've been a success
                     nextJob.setResult(JobResult.SUCCESS);
                 }
-                catch (RunnerNotInitializedException e) { /* TODO */ e.printStackTrace(); }
-                catch (InvalidApplicationException e) { /* TODO */ e.printStackTrace(); }
-                catch (SeleniumIdentificationException e) { /* TODO */ e.printStackTrace(); }
+                catch (RunnerNotInitializedException | InvalidApplicationException | SeleniumIdentificationException e) {
+                    System.err.println("A job has failed, but the runner will reset and continue execution.");
+                    e.printStackTrace();
+
+                    // Flag the job as failed
+                    nextJob.setResult(JobResult.FAILURE);
+                }
 
                 // Reopen availability and notify the manager
                 waiting = true;
                 jobManager.indicateAvailability(this);
             }
         }
-        catch (InterruptedException | JobManagerStoppedException e) { /* TODO */ e.printStackTrace(); }
+        catch (InterruptedException | JobManagerStoppedException e) {
+            System.err.println("A runner has unrecoverably failed. It will need to be reinitialized with the manager.");
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/SeleniumRunner.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/SeleniumRunner.java
@@ -85,7 +85,6 @@ public class SeleniumRunner implements Runner {
                 catch (RunnerNotInitializedException | InvalidApplicationException | SeleniumIdentificationException e) {
                     // TODO: Either scope logging to the runner, or delegate this to the job's callback with a faillback to the manager
                     System.err.println("A job has failed, but the runner will reset and continue execution.");
-                    e.printStackTrace();
 
                     // Flag the job as failed
                     nextJob.setResult(JobResult.FAILURE);


### PR DESCRIPTION
Introduces some better failure-handling for jobs. The runner should recover gracefully, mark the job as erroneous, and notify the manager so the GUI has an opportunity to reflect the error to the user.