### PR TITLE
bugfix/Globus-flow-hangup

### DIFF
--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/authentication/globus/GlobusAuthenticationFlow.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/authentication/globus/GlobusAuthenticationFlow.java
@@ -73,21 +73,30 @@ public class GlobusAuthenticationFlow implements SeleniumAuthenticationFlow {
                 .until(d -> d.findElement(By.cssSelector("input[type=\"submit\"]")))
                 .click();
 
-        // Locate the confirmation iframe
-        System.out.println("Locating confirmation iframe...");
-        WebElement confirmFrame = new WebDriverWait(driver, Duration.ofSeconds(10))
-                .until(d -> d.findElement(By.tagName("iframe")));
+        for (int retry = 0; retry < 3; retry++) {
+            // Locate the confirmation iframe
+            System.out.println("Locating confirmation iframe...");
+            WebElement confirmFrame = new WebDriverWait(driver, Duration.ofSeconds(10))
+                    .until(d -> d.findElement(By.tagName("iframe")));
 
-        // Switch to the account confirmation frame
-        driver.switchTo().frame(confirmFrame);
+            // Switch to the account confirmation frame
+            driver.switchTo().frame(confirmFrame);
 
-        // Acknowledge account
-        System.out.println("Acknowledging account...");
-        new WebDriverWait(driver, Duration.ofSeconds(10))
-                .until(d -> d.findElement(By.tagName("button")))
-                .click();
-
-        // Swap back to the window
-        driver.switchTo().defaultContent();
+            // Acknowledge account
+            try {
+                System.out.println("Acknowledging account (try " + (retry+1) + " of 3)...");
+                new WebDriverWait(driver, Duration.ofSeconds(10))
+                        .until(d -> d.findElement(By.tagName("button")))
+                        .click();
+                
+                // Successful; break to avoid retrying
+                break;
+            } catch (Exception e) {
+                System.out.println("Failed to identify the confirmation button");
+            } finally {
+                // Swap back to the window
+                driver.switchTo().defaultContent();
+            }
+        }
     }
 }


### PR DESCRIPTION
Occasionally, the Globus authentication flow breaks at the point of
confirmation. This is after being authenticated by Globus, after being
redirected to KBase's callback, but before being dropped into the target
narrative. KBase presents a confirmation button which we need to click.

Rather than spending more time trying to reproduce the conditions that
lead to this error (it's sporadic and there are several layers to the
DOM we're interacting with), this simple retry logic should (hopefully)
resolve the problem, assuming it's a timing problem.

Fixes #32 (hopefully)