### PR TITLE
fix(kbasehelper): reload items-to-remove to prevent stale refs

### DIFF
--- a/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/KBaseHelper.java
+++ b/src/main/java/edu/iastate/ece/sd/sdmay2126/runner/selenium/KBaseHelper.java
@@ -122,8 +122,11 @@ public class KBaseHelper {
         // Clear previous selections
         List<WebElement> selectedItems = selectedItemsPane.findElements(By.cssSelector(".row"));
         System.out.printf("  Removing %d items...%n", selectedItems.size());
-        for (WebElement previousOption : selectedItems) {
-            previousOption.findElement(By.cssSelector("span[class='fa fa-minus-circle']")).click();
+        while (!selectedItems.isEmpty()) {
+            selectedItems.get(0).findElement(By.cssSelector("span[class='fa fa-minus-circle']")).click();
+
+            // Reload the remaining items so our references don't become stale
+            selectedItems = selectedItemsPane.findElements(By.cssSelector(".row"));
         }
 
         // Make new selections


### PR DESCRIPTION
I did not observe this issue with simple lists, only with the dynamic option selections.